### PR TITLE
add meta tags for previews

### DIFF
--- a/src/components/Layout.astro
+++ b/src/components/Layout.astro
@@ -23,6 +23,15 @@ const pathnameWithSlash = pathname.endsWith('/') ? pathname : `${pathname}/`;
     <meta name="generator" content="Rustular 0.0.0" />
     <meta name="darkreader-lock">
     <title>{title} - Rustular</title>
+    <meta name="title" content="Rustular"/>
+    <meta name="description" content="A drop-in metaframework that supercharges any web application."/>
+    <meta property="og:type" content="website"/>
+    <meta property="og:url" content="https://rustular.com/"/>
+    <meta property="og:title" content="Rustular"/>
+    <meta property="og:description" content="A drop-in metaframework that supercharges any web application."/>
+    <meta property="twitter:url" content="https://rustular.com/"/>
+    <meta property="twitter:title" content="Rustular"/>
+    <meta property="twitter:description" content="A drop-in metaframework that supercharges any web application."/>
     <script
       defer
       data-domain="rustular.com"


### PR DESCRIPTION
This allows https://rustular.com/ to offer a preview when shared in chat platforms or the usual social networks. 